### PR TITLE
add working_dir to docker-compose.yml and proxy Environ support

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,3 +11,4 @@ services:
       - 53773
     volumes:
       - ./:/home/irisowner/irisdev
+    working_dir: /home/irisowner

--- a/src/community/csvgen.cls
+++ b/src/community/csvgen.cls
@@ -291,6 +291,12 @@ ClassMethod GetStreamFromURL(URL As %String, SSLConf As %String = "default") As 
     Set httprequest.Server = $P(URL,"/")
     Set httprequest.Https = 1
     Set httprequest.SSLConfiguration = SSLConf
+    set proxy=$System.Util.GetEnviron("https_proxy")
+    if proxy'="" {
+      Do ##class(%Net.URLParser).Parse(proxy,.pr)
+      set:$G(pr("host"))'="" httprequest.ProxyHTTPS=1,httprequest.ProxyTunnel=1,httprequest.ProxyPort=pr("port"),httprequest.ProxyServer=pr("host")
+      set:$G(pr("username"))'=""&&($G(pr("password"))'="") httprequest.ProxyAuthorization="Basic "_$system.Encryption.Base64Encode(pr("username")_":"_pr("password"))
+    }
     set filename="/"_$P(URL,"/",2,*)
     $$$TOE(sc,httprequest.Get(filename))
     Set stream = httprequest.HttpResponse.Data


### PR DESCRIPTION
After starting the container, the process is in constant restart:
#docker ps
CONTAINER ID   IMAGE         COMMAND                  CREATED              STATUS                            PORTS     NAMES
7e8d85439d00   csvgen_iris   "/tini -- /docker-en…"   About a minute ago   Restarting (134) 31 seconds ago             csvgen_iris_1
#docker-compose exec iris iris session iris
Error response from daemon: Container 7e8d85439d00509e79f6f3031f108bf7881ee28ef7b8cdea7b8df25720cb1bb8 is restarting, wait until the container i  s running

When starting in manual mode, an error is visible:
#docker-compose run iris
Creating csvgen_iris_run ... done
terminate called after throwing an instance of 'std::runtime_error'
  what():  Unable to find/open file iris-main.log in current directory /home/irisowner/irisdev
/docker-entrypoint.sh: line 138:     8 Aborted                 (core dumped) /iris-main "$@"
ERROR: 134

The problem is solved in docker-compose.yml by adding
working_dir: /home/iris owner. Thanks @mrdaimor